### PR TITLE
Fix Page Component Type Error

### DIFF
--- a/frontend/src/app/courses/[id]/page.tsx
+++ b/frontend/src/app/courses/[id]/page.tsx
@@ -14,7 +14,7 @@ interface Module {
   title: string
 }
 
-export function CourseDetail() {
+const CourseDetail = () => {
   const { id } = useParams()
   const [courseName, setCourseName] = useState('')
   const [coursePrevImg, setCoursePrevImg] = useState('')


### PR DESCRIPTION
**Description:**

This pull request resolves a type error related to the `CourseDetail` component in `src/app/courses/[id]/page.tsx`. The error indicated that `CourseDetail` is not a valid Page export field in Next.js.

**Changes Made:**

- **Corrected Page Component Export:**
  - Ensured that the page component in `src/app/courses/[id]/page.tsx` is correctly exported as a default export to conform with Next.js requirements.

- **Updated Component Definition:**
  - Verified and updated the component definition to match the expected types for a Next.js Page.

**Details:**
- Updated the `page.tsx` to ensure it properly exports a React component that meets the type requirements for Next.js pages.

**Testing:**
- Rebuilt the application to confirm that the type error has been resolved and the build completes successfully.

**Related Issues:**
- Resolves build failure on Vercel due to type mismatches in page components.