### PR TITLE
Fix Page Component Type Error

### DIFF
--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -8,7 +8,7 @@ import { useRouter } from "next/navigation";
 import axios from "axios";
 import { useAuth } from "@/app/context/AuthContext";
 
-function SignIn() {
+const SignIn = () => {
     const [email, setEmail] = useState<string>("");
     const [password, setPassword] = useState<string>("");
     const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/frontend/src/app/auth/register/page.tsx
+++ b/frontend/src/app/auth/register/page.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from "react";
 import { z } from "zod"
 
-function SignUp() {
+const SignUp = () => {
     const [email, setEmail] = useState<string>("");
     const [password, setPassword] = useState<string>("");
     const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/frontend/src/app/courses/[id]/modules/page.tsx
+++ b/frontend/src/app/courses/[id]/modules/page.tsx
@@ -10,7 +10,7 @@ import { useState } from 'react';
 import { Spinner } from '@nextui-org/spinner'
 import LessonContent from '@/app/components/content';
 
-export default function CourseDetail() {
+const Modules = () => {
   const [openTag, setOpenTag] = useState(null);
   const [selectedLesson, setSelectedLesson] = useState(null);
   const [selectedModule, setSelectedModule] = useState(null);
@@ -112,3 +112,5 @@ export default function CourseDetail() {
     </div>
   );
 }
+
+export default Modules;

--- a/frontend/src/app/courses/page.tsx
+++ b/frontend/src/app/courses/page.tsx
@@ -10,7 +10,7 @@ import Modal from "@/app/components/modal";
 import { set } from "zod";
 
 
-export function CourseList() {
+const CourseList = () => {
     const { courses, loading, error } = useCourses();
     const [open, setOpen] = useState(false)
 


### PR DESCRIPTION
**Description:**

This pull request resolves a type error related to the `CourseList`, `Modules`, `SignIn`, `SignUp` component in `src/app/courses/page.tsx`, `src/app/courses/[id]/modules/page.tsx`, `src/app/auth/login/page.tsx`, `src/app/auth/register/page.tsx`. The error indicated that all of them are not a valid Page export field in Next.js.

**Changes Made:**

- **Corrected Page Component Export:**
  - Ensured that the page components are correctly exported as a default export to conform with Next.js requirements.

- **Updated Component Definition:**
  - Verified and updated the component definition to match the expected types for a Next.js Page.

**Details:**
- Updated the `page.tsx` to ensure it properly exports a React component that meets the type requirements for Next.js pages.

**Testing:**
- Rebuilt the application to confirm that the type error has been resolved and the build completes successfully.

**Related Issues:**
- Resolves build failure on Vercel due to type mismatches in page components.